### PR TITLE
feature/mandatory-UI-arn

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -74,6 +74,11 @@ module "metaflow-ui" {
   standard_tags             = var.tags
 }
 
+moved {
+  from = module.metaflow-ui[0]
+  to   = module.metaflow-ui
+}
+
 module "metaflow-computation" {
   source = "./modules/computation"
 

--- a/main.tf
+++ b/main.tf
@@ -41,7 +41,6 @@ module "metaflow-metadata-service" {
 
 module "metaflow-ui" {
   source = "./modules/ui"
-  count  = var.ui_certificate_arn == "" ? 0 : 1
 
   resource_prefix = local.resource_prefix
   resource_suffix = local.resource_suffix

--- a/outputs.tf
+++ b/outputs.tf
@@ -115,12 +115,12 @@ output "migration_function_arn" {
 }
 
 output "ui_alb_dns_name" {
-  value       = (length(module.metaflow-ui) > 0) ? module.metaflow-ui[0].alb_dns_name : ""
+  value       = module.metaflow-ui.alb_dns_name
   description = "UI ALB DNS name"
 }
 
 output "ui_alb_arn" {
-  value       = (length(module.metaflow-ui) > 0) ? module.metaflow-ui[0].alb_arn : ""
+  value       = module.metaflow-ui.alb_arn
   description = "UI ALB ARN"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -161,8 +161,7 @@ variable "vpc_id" {
 
 variable "ui_certificate_arn" {
   type        = string
-  default     = ""
-  description = "SSL certificate for UI. If set to empty string, UI is disabled. "
+  description = "SSL certificate for UI."
 }
 
 variable "ui_allow_list" {


### PR DESCRIPTION
I would like to make the Metaflow UI a mandatory component for a Metaflow deployment.

The problem I am having is with the UI `count`:
- this count value depends on the string value of the SSL certificate ARN
- I am typically creating those SSL certificates in another module
- the string value for the ARNs is not known at plan time if they do not yet exist (i.e. when the module has not been created before)
- as such, the value of the count for the Metaflow UI cannot be determined, meaning the `terraform plan` fails with this error:

```
╷
│ Error: Invalid count argument
│ 
│   on .terraform/modules/ncr_metaflow.metaflow/main.tf line 44, in module "metaflow-ui":
│   44:   count  = var.ui_certificate_arn == "" ? 0 : 1
│ 
│ The "count" value depends on resource attributes that cannot be determined until apply, so Terraform cannot predict how many instances will be created. To work around this, use the -target
│ argument to first apply only the resources that the count depends on.
╵
╷
```

The workaround suggested requires that we run the terraform apply in two stages. This is not desirable because:
- it is not compatible with our CI workflow
- we want to be able to create both this module and the SSL modules at the same time, to speed up deployments of new infrastructure

Other things that I have tried:
- Setting the default value to be `null`, rather than an empty string, with the hope that terraform would check the type for the input `ui_certificate_arn` variable. It did not.
- Adding a `lifecycle` precondition that checks the `ui_certificate_arn` value, but these are [not supported for modules](https://github.com/hashicorp/terraform/issues/27360)

We could also add a second variable, `create_ui`, which we instead use as the conditional to count, rather than the string value of the ARN. This would be similar to how the [terraform-eks](https://github.com/terraform-aws-modules/terraform-aws-eks) module handles conditional resource creation.

The trade-off of this change is that we end up with a change in our terraform-aws fork that will almost certainly not be accepted into the upstream Outerbounds repo, which might make proposing changes later on harder.