### PR TITLE
IN-48: Upgrade to AWS provider v5

### DIFF
--- a/modules/datastore/rds.tf
+++ b/modules/datastore/rds.tf
@@ -114,7 +114,7 @@ resource "aws_db_instance" "this" {
   engine_version            = var.db_engine_version
   instance_class            = var.db_instance_type                                         # Hardware configuration
   identifier                = "${var.resource_prefix}${var.db_name}${var.resource_suffix}" # used for dns hostname needs to be customer unique in region
-  name                      = var.db_name                                                  # unique id for CLI commands (name of DB table which is why we're not adding the prefix as no conflicts will occur and the API expects this table name)
+  db_name                   = var.db_name                                                  # unique id for CLI commands (name of DB table which is why we're not adding the prefix as no conflicts will occur and the API expects this table name)
   username                  = var.db_username
   password                  = random_password.this.result
   db_subnet_group_name      = aws_db_subnet_group.this.id


### PR DESCRIPTION
IN-48: Upgrade to AWS provider v5, aws_db_instance requires the new db_name parameter.