### PR TITLE
Update aws_batch_job_queue resource with latest non-deprecated parameter 'compute_environment_order'.

### DIFF
--- a/modules/computation/batch.tf
+++ b/modules/computation/batch.tf
@@ -79,9 +79,10 @@ resource "aws_batch_job_queue" "this" {
   name     = local.batch_queue_name
   state    = "ENABLED"
   priority = 1
-  compute_environments = [
-    aws_batch_compute_environment.this.arn
-  ]
+  compute_environment_order {
+    order               = 1
+    compute_environment = aws_batch_compute_environment.this.arn
+  }
 
   tags = var.standard_tags
 }


### PR DESCRIPTION
Fixes the warning:

```
╷
│ Warning: Attribute Deprecated
│ 
│   with module.ncr_metaflow.module.metaflow.module.metaflow-computation.aws_batch_job_queue.this,
│   on ../../../../terraform-aws-metaflow/modules/computation/batch.tf line 82, in resource "aws_batch_job_queue" "this":
│   82:   compute_environments = [
│   83:     aws_batch_compute_environment.this.arn
│   84:   ]
│ 
│ This parameter will be replaced by `compute_environment_order`.
│ 
│ (and one more similar warning elsewhere)
```