### PR TITLE
Enable SSL options for the metaflow services, defaulting to 'disable' for backward compatibility.

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,11 @@ You can find a more complete example that uses this module but also includes set
 | <a name="input_compute_environment_instance_types"></a> [compute\_environment\_instance\_types](#input\_compute\_environment\_instance\_types) | The instance types for the compute environment | `list(string)` | <pre>[<br/>  "c4.large",<br/>  "c4.xlarge",<br/>  "c4.2xlarge",<br/>  "c4.4xlarge",<br/>  "c4.8xlarge"<br/>]</pre> | no |
 | <a name="input_compute_environment_max_vcpus"></a> [compute\_environment\_max\_vcpus](#input\_compute\_environment\_max\_vcpus) | Maximum VCPUs for Batch Compute Environment [16-96] | `number` | `64` | no |
 | <a name="input_compute_environment_min_vcpus"></a> [compute\_environment\_min\_vcpus](#input\_compute\_environment\_min\_vcpus) | Minimum VCPUs for Batch Compute Environment [0-16] for EC2 Batch Compute Environment (ignored for Fargate) | `number` | `8` | no |
+| <a name="input_database_ssl_cert_path"></a> [database\_ssl\_cert\_path](#input\_database\_ssl\_cert\_path) | The database SSL certificate path | `string` | `""` | no |
+| <a name="input_database_ssl_key_path"></a> [database\_ssl\_key\_path](#input\_database\_ssl\_key\_path) | The database SSL key path | `string` | `""` | no |
+| <a name="input_database_ssl_mode"></a> [database\_ssl\_mode](#input\_database\_ssl\_mode) | The database SSL mode | `string` | `"disable"` | no |
+| <a name="input_database_ssl_root_cert"></a> [database\_ssl\_root\_cert](#input\_database\_ssl\_root\_cert) | The database SSL root certificate | `string` | `""` | no |
+| <a name="input_db_allow_major_version_upgrade"></a> [db\_allow\_major\_version\_upgrade](#input\_db\_allow\_major\_version\_upgrade) | Allow major version upgrades for the RDS instance | `bool` | `false` | no |
 | <a name="input_db_engine_version"></a> [db\_engine\_version](#input\_db\_engine\_version) | n/a | `string` | `"11"` | no |
 | <a name="input_db_identifier_prefix"></a> [db\_identifier\_prefix](#input\_db\_identifier\_prefix) | Identifier prefix for the RDS instance | `string` | `""` | no |
 | <a name="input_db_instance_tags"></a> [db\_instance\_tags](#input\_db\_instance\_tags) | A map of additional tags for the DB instance | `map(string)` | `{}` | no |

--- a/main.tf
+++ b/main.tf
@@ -38,6 +38,10 @@ module "metaflow-metadata-service" {
   database_name                    = module.metaflow-datastore.database_name
   database_password                = module.metaflow-datastore.database_password
   database_username                = module.metaflow-datastore.database_username
+  database_ssl_mode                = var.database_ssl_mode
+  database_ssl_cert_path           = var.database_ssl_cert_path
+  database_ssl_key_path            = var.database_ssl_key_path
+  database_ssl_root_cert           = var.database_ssl_root_cert
   db_migrate_lambda_zip_file       = var.db_migrate_lambda_zip_file
   db_migrate_lambda_runtime        = var.db_migrate_lambda_runtime
   datastore_s3_bucket_kms_key_arn  = module.metaflow-datastore.datastore_s3_bucket_kms_key_arn

--- a/modules/datastore/rds.tf
+++ b/modules/datastore/rds.tf
@@ -123,7 +123,7 @@ resource "aws_db_instance" "this" {
   final_snapshot_identifier = local.rds_final_snapshot_identifier # Snapshot upon delete
   vpc_security_group_ids    = [aws_security_group.rds_security_group.id]
   ca_cert_identifier        = var.ca_cert_identifier
-  parameter_group_name      = length(var.db_parameters) > 0 ? aws_db_parameter_group.this[0].name : null
+  parameter_group_name      = length(var.db_parameters) > 0 ? aws_db_parameter_group.this[0].name : "default.${var.db_engine}${var.db_engine_version}"
 
   apply_immediately           = var.apply_immediately
   maintenance_window          = length(var.maintenance_window) > 0 ? var.maintenance_window : null

--- a/modules/metadata-service/README.md
+++ b/modules/metadata-service/README.md
@@ -88,6 +88,10 @@ If the `access_list_cidr_blocks` variable is set, only traffic originating from 
 | <a name="input_api_basic_auth"></a> [api\_basic\_auth](#input\_api\_basic\_auth) | Enable basic auth for API Gateway? (requires key export) | `bool` | `true` | no |
 | <a name="input_database_name"></a> [database\_name](#input\_database\_name) | The database name | `string` | `"metaflow"` | no |
 | <a name="input_database_password"></a> [database\_password](#input\_database\_password) | The database password | `string` | n/a | yes |
+| <a name="input_database_ssl_cert_path"></a> [database\_ssl\_cert\_path](#input\_database\_ssl\_cert\_path) | The database SSL certificate path | `string` | `""` | no |
+| <a name="input_database_ssl_key_path"></a> [database\_ssl\_key\_path](#input\_database\_ssl\_key\_path) | The database SSL key path | `string` | `""` | no |
+| <a name="input_database_ssl_mode"></a> [database\_ssl\_mode](#input\_database\_ssl\_mode) | The database SSL mode | `string` | `"disable"` | no |
+| <a name="input_database_ssl_root_cert"></a> [database\_ssl\_root\_cert](#input\_database\_ssl\_root\_cert) | The database SSL root certificate | `string` | `""` | no |
 | <a name="input_database_username"></a> [database\_username](#input\_database\_username) | The database username | `string` | n/a | yes |
 | <a name="input_datastore_s3_bucket_kms_key_arn"></a> [datastore\_s3\_bucket\_kms\_key\_arn](#input\_datastore\_s3\_bucket\_kms\_key\_arn) | The ARN of the KMS key used to encrypt the Metaflow datastore S3 bucket | `string` | n/a | yes |
 | <a name="input_db_migrate_lambda_runtime"></a> [db\_migrate\_lambda\_runtime](#input\_db\_migrate\_lambda\_runtime) | Runtime version for the DB migrate lambda | `string` | `"python3.7"` | no |

--- a/modules/metadata-service/ecs.tf
+++ b/modules/metadata-service/ecs.tf
@@ -45,7 +45,11 @@ resource "aws_ecs_task_definition" "this" {
       {"name": "MF_METADATA_DB_NAME", "value": "${var.database_name}"},
       {"name": "MF_METADATA_DB_PORT", "value": "5432"},
       {"name": "MF_METADATA_DB_PSWD", "value": "${var.database_password}"},
-      {"name": "MF_METADATA_DB_USER", "value": "${var.database_username}"}
+      {"name": "MF_METADATA_DB_USER", "value": "${var.database_username}"},
+      {"name": "MF_METADATA_DB_SSL_MODE", "value": "${var.database_ssl_mode}"},
+      {"name": "MF_METADATA_DB_SSL_CERT_PATH", "value": "${var.database_ssl_cert_path}"},
+      {"name": "MF_METADATA_DB_SSL_KEY_PATH", "value": "${var.database_ssl_key_path}"},
+      {"name": "MF_METADATA_DB_SSL_ROOT_CERT", "value": "${var.database_ssl_root_cert}"}
     ],
     "logConfiguration": {
         "logDriver": "awslogs",

--- a/modules/metadata-service/variables.tf
+++ b/modules/metadata-service/variables.tf
@@ -25,6 +25,30 @@ variable "database_username" {
   description = "The database username"
 }
 
+variable "database_ssl_mode" {
+  type        = string
+  default     = "disable"
+  description = "The database SSL mode"
+}
+
+variable "database_ssl_cert_path" {
+  type        = string
+  default     = ""
+  description = "The database SSL certificate path"
+}
+
+variable "database_ssl_key_path" {
+  type        = string
+  default     = ""
+  description = "The database SSL key path"
+}
+
+variable "database_ssl_root_cert" {
+  type        = string
+  default     = ""
+  description = "The database SSL root certificate"
+}
+
 variable "datastore_s3_bucket_kms_key_arn" {
   type        = string
   description = "The ARN of the KMS key used to encrypt the Metaflow datastore S3 bucket"

--- a/modules/metadata-service/variables.tf
+++ b/modules/metadata-service/variables.tf
@@ -29,6 +29,11 @@ variable "database_ssl_mode" {
   type        = string
   default     = "disable"
   description = "The database SSL mode"
+
+  validation {
+    condition     = contains(["disable", "allow", "prefer", "require", "verify-ca", "verify-full"], var.database_ssl_mode)
+    error_message = "'database_ssl_mode' must be one of 'disable', 'allow', 'prefer', 'require', 'verify-ca', 'verify-full'"
+  }
 }
 
 variable "database_ssl_cert_path" {

--- a/variables.tf
+++ b/variables.tf
@@ -63,6 +63,30 @@ variable "db_allow_major_version_upgrade" {
   default     = false
 }
 
+variable "database_ssl_mode" {
+  type        = string
+  default     = "disable"
+  description = "The database SSL mode"
+}
+
+variable "database_ssl_cert_path" {
+  type        = string
+  default     = ""
+  description = "The database SSL certificate path"
+}
+
+variable "database_ssl_key_path" {
+  type        = string
+  default     = ""
+  description = "The database SSL key path"
+}
+
+variable "database_ssl_root_cert" {
+  type        = string
+  default     = ""
+  description = "The database SSL root certificate"
+}
+
 variable "enable_custom_batch_container_registry" {
   type        = bool
   default     = false


### PR DESCRIPTION
Enable SSL options for the metaflow services, defaulting to 'disable' for backward compatibility.

Also default to the 'default' postgres parameter group, this fixes an issue where no paramater group options are present when they previously were and the paramater group is not detached.