### PR TITLE
IN-220: Allow the metaflow S3 bucket to be tagged independently of the other  resources. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ You can find a more complete example that uses this module but also includes set
 | <a name="input_resource_prefix"></a> [resource\_prefix](#input\_resource\_prefix) | string prefix for all resources | `string` | `"metaflow"` | no |
 | <a name="input_resource_suffix"></a> [resource\_suffix](#input\_resource\_suffix) | string suffix for all resources | `string` | `""` | no |
 | <a name="input_s3_bucket_name"></a> [s3\_bucket\_name](#input\_s3\_bucket\_name) | The name of the S3 bucket used for Metaflow datastore | `string` | `""` | no |
+| <a name="input_s3_bucket_tags"></a> [s3\_bucket\_tags](#input\_s3\_bucket\_tags) | A map of additional tags for the S3 bucket | `map(string)` | `{}` | no |
 | <a name="input_subnet1_id"></a> [subnet1\_id](#input\_subnet1\_id) | First subnet used for availability zone redundancy | `string` | n/a | yes |
 | <a name="input_subnet2_id"></a> [subnet2\_id](#input\_subnet2\_id) | Second subnet used for availability zone redundancy | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | aws tags | `map(string)` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -23,6 +23,7 @@ module "metaflow-datastore" {
   db_instance_tags = var.db_instance_tags
 
   s3_bucket_name     = var.s3_bucket_name
+  s3_bucket_tags     = var.s3_bucket_tags
   bucket_key_enabled = var.bucket_key_enabled
 }
 

--- a/modules/common/.terraform-docs.yml
+++ b/modules/common/.terraform-docs.yml
@@ -1,0 +1,10 @@
+formatter: markdown
+sections:
+  show-all: true
+output:
+  file: "README.md"
+  mode: inject
+  template: |-
+    <!-- BEGIN_TF_DOCS -->
+    {{ .Content }}
+    <!-- END_TF_DOCS -->

--- a/modules/common/README.md
+++ b/modules/common/README.md
@@ -1,4 +1,20 @@
 <!-- BEGIN_TF_DOCS -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+No providers.
+
+## Modules
+
+No modules.
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 No inputs.
@@ -8,4 +24,5 @@ No inputs.
 | Name | Description |
 |------|-------------|
 | <a name="output_default_metadata_service_container_image"></a> [default\_metadata\_service\_container\_image](#output\_default\_metadata\_service\_container\_image) | n/a |
+| <a name="output_default_ui_static_container_image"></a> [default\_ui\_static\_container\_image](#output\_default\_ui\_static\_container\_image) | n/a |
 <!-- END_TF_DOCS -->

--- a/modules/computation/.terraform-docs.yml
+++ b/modules/computation/.terraform-docs.yml
@@ -1,0 +1,10 @@
+formatter: markdown
+sections:
+  show-all: true
+output:
+  file: "README.md"
+  mode: inject
+  template: |-
+    <!-- BEGIN_TF_DOCS -->
+    {{ .Content }}
+    <!-- END_TF_DOCS -->

--- a/modules/datastore/.terraform-docs.yml
+++ b/modules/datastore/.terraform-docs.yml
@@ -1,0 +1,10 @@
+formatter: markdown
+sections:
+  show-all: true
+output:
+  file: "README.md"
+  mode: inject
+  template: |-
+    <!-- BEGIN_TF_DOCS -->
+    {{ .Content }}
+    <!-- END_TF_DOCS -->

--- a/modules/datastore/README.md
+++ b/modules/datastore/README.md
@@ -74,6 +74,7 @@ No modules.
 | <a name="input_resource_prefix"></a> [resource\_prefix](#input\_resource\_prefix) | Prefix given to all AWS resources to differentiate between applications | `string` | n/a | yes |
 | <a name="input_resource_suffix"></a> [resource\_suffix](#input\_resource\_suffix) | Suffix given to all AWS resources to differentiate between environment and workspace | `string` | n/a | yes |
 | <a name="input_s3_bucket_name"></a> [s3\_bucket\_name](#input\_s3\_bucket\_name) | The name of the S3 bucket used for Metaflow datastore | `string` | `""` | no |
+| <a name="input_s3_bucket_tags"></a> [s3\_bucket\_tags](#input\_s3\_bucket\_tags) | A map of additional tags for the S3 bucket | `map(string)` | `{}` | no |
 | <a name="input_standard_tags"></a> [standard\_tags](#input\_standard\_tags) | The standard tags to apply to every AWS resource. | `map(string)` | n/a | yes |
 | <a name="input_subnet1_id"></a> [subnet1\_id](#input\_subnet1\_id) | First subnet used for availability zone redundancy | `string` | n/a | yes |
 | <a name="input_subnet2_id"></a> [subnet2\_id](#input\_subnet2\_id) | Second subnet used for availability zone redundancy | `string` | n/a | yes |

--- a/modules/datastore/s3.tf
+++ b/modules/datastore/s3.tf
@@ -14,6 +14,7 @@ resource "aws_s3_bucket" "this" {
 
   tags = merge(
     var.standard_tags,
+    var.s3_bucket_tags,
     {
       Metaflow = "true"
     }

--- a/modules/datastore/variables.tf
+++ b/modules/datastore/variables.tf
@@ -87,6 +87,12 @@ variable "db_instance_tags" {
   default     = {}
 }
 
+variable "s3_bucket_tags" {
+  description = "A map of additional tags for the S3 bucket"
+  type        = map(string)
+  default     = {}
+}
+
 variable "subnet1_id" {
   type        = string
   description = "First subnet used for availability zone redundancy"

--- a/modules/metadata-service/.terraform-docs.yml
+++ b/modules/metadata-service/.terraform-docs.yml
@@ -1,0 +1,10 @@
+formatter: markdown
+sections:
+  show-all: true
+output:
+  file: "README.md"
+  mode: inject
+  template: |-
+    <!-- BEGIN_TF_DOCS -->
+    {{ .Content }}
+    <!-- END_TF_DOCS -->

--- a/modules/step-functions/.terraform-docs.yml
+++ b/modules/step-functions/.terraform-docs.yml
@@ -1,0 +1,10 @@
+formatter: markdown
+sections:
+  show-all: true
+output:
+  file: "README.md"
+  mode: inject
+  template: |-
+    <!-- BEGIN_TF_DOCS -->
+    {{ .Content }}
+    <!-- END_TF_DOCS -->

--- a/modules/step-functions/README.md
+++ b/modules/step-functions/README.md
@@ -7,6 +7,46 @@ This builds on top of the functionality provided by the `computation` module, wh
 To read more, see [the Metaflow docs](https://docs.metaflow.org/going-to-production-with-metaflow/scheduling-metaflow-flows)
 
 <!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_dynamodb_table.step_functions_state_table](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table) | resource |
+| [aws_iam_role.eventbridge_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role.step_functions_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.eventbridge_step_functions_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.step_functions_batch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.step_functions_cloudwatch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.step_functions_dynamodb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.step_functions_eventbridge](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.step_functions_s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.eventbridge_assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.eventbridge_step_functions_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.step_functions_assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.step_functions_batch_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.step_functions_cloudwatch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.step_functions_dynamodb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.step_functions_eventbridge](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.step_functions_s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |

--- a/modules/ui/.terraform-docs.yml
+++ b/modules/ui/.terraform-docs.yml
@@ -1,0 +1,10 @@
+formatter: markdown
+sections:
+  show-all: true
+output:
+  file: "README.md"
+  mode: inject
+  template: |-
+    <!-- BEGIN_TF_DOCS -->
+    {{ .Content }}
+    <!-- END_TF_DOCS -->

--- a/variables.tf
+++ b/variables.tf
@@ -191,6 +191,12 @@ variable "db_instance_tags" {
   default     = {}
 }
 
+variable "s3_bucket_tags" {
+  description = "A map of additional tags for the S3 bucket"
+  type        = map(string)
+  default     = {}
+}
+
 variable "ui_alb_internal" {
   type        = bool
   description = "Defines whether the ALB for the UI is internal"


### PR DESCRIPTION
The current requirement for this is that we can tag the bucket with S3Backup=true for AWS Backup.

Also update all tf docs for the root and submodules. Include docs config for easy updates of each README.md