### PR TITLE
IN-134: Add optional support for ELB access logging to S3 bucket.

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ You can find a more complete example that uses this module but also includes set
 | <a name="input_db_parameters"></a> [db\_parameters](#input\_db\_parameters) | A map of parameters to apply to the DB instance | `map(string)` | `{}` | no |
 | <a name="input_ecs_cluster_settings"></a> [ecs\_cluster\_settings](#input\_ecs\_cluster\_settings) | Settings for the ECS cluster | `map(string)` | `{}` | no |
 | <a name="input_enable_custom_batch_container_registry"></a> [enable\_custom\_batch\_container\_registry](#input\_enable\_custom\_batch\_container\_registry) | Provisions infrastructure for custom Amazon ECR container registry if enabled | `bool` | `false` | no |
+| <a name="input_enable_lb_access_logging"></a> [enable\_lb\_access\_logging](#input\_enable\_lb\_access\_logging) | Enable access logging for all load balancers | `bool` | `false` | no |
 | <a name="input_enable_step_functions"></a> [enable\_step\_functions](#input\_enable\_step\_functions) | Provisions infrastructure for step functions if enabled | `bool` | n/a | yes |
 | <a name="input_extra_ui_backend_env_vars"></a> [extra\_ui\_backend\_env\_vars](#input\_extra\_ui\_backend\_env\_vars) | Additional environment variables for UI backend container | `map(string)` | `{}` | no |
 | <a name="input_extra_ui_static_env_vars"></a> [extra\_ui\_static\_env\_vars](#input\_extra\_ui\_static\_env\_vars) | Additional environment variables for UI static app | `map(string)` | `{}` | no |
@@ -132,6 +133,7 @@ You can find a more complete example that uses this module but also includes set
 | <a name="input_load_balancer_name_prefix"></a> [load\_balancer\_name\_prefix](#input\_load\_balancer\_name\_prefix) | Prefix for all load balancer names | `string` | `""` | no |
 | <a name="input_maintenance_window"></a> [maintenance\_window](#input\_maintenance\_window) | Maintenance Window in format "ddd:hh24:mi-ddd:hh24:mi" eg. "Mon:00:00-Mon:03:00", or leave blank to randomise | `string` | `""` | no |
 | <a name="input_metadata_service_container_image"></a> [metadata\_service\_container\_image](#input\_metadata\_service\_container\_image) | Container image for metadata service | `string` | `""` | no |
+| <a name="input_region_available_before_2022"></a> [region\_available\_before\_2022](#input\_region\_available\_before\_2022) | Set to false if the region is not available before 2022. This is used for the ELB access logging bucket policy, as older regions have different bucket policy principle statements, see: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/enable-access-logging.html#attach-bucket-policy | `bool` | `true` | no |
 | <a name="input_resource_prefix"></a> [resource\_prefix](#input\_resource\_prefix) | string prefix for all resources | `string` | `"metaflow"` | no |
 | <a name="input_resource_suffix"></a> [resource\_suffix](#input\_resource\_suffix) | string suffix for all resources | `string` | `""` | no |
 | <a name="input_s3_bucket_name"></a> [s3\_bucket\_name](#input\_s3\_bucket\_name) | The name of the S3 bucket used for Metaflow datastore | `string` | `""` | no |

--- a/data.tf
+++ b/data.tf
@@ -1,3 +1,5 @@
 data "aws_region" "current" {}
 
 data "aws_caller_identity" "current" {}
+
+data "aws_elb_service_account" "current" {}

--- a/locals.tf
+++ b/locals.tf
@@ -9,6 +9,9 @@ locals {
   aws_region     = data.aws_region.current.name
   aws_account_id = data.aws_caller_identity.current.account_id
 
+  aws_region_split = split("-", local.aws_region)
+  aws_region_short = "${local.aws_region_split[0]}${substr(local.aws_region_split[1], 0, 1)}${local.aws_region_split[2]}"
+
   batch_s3_task_role_name   = "${local.resource_prefix}batch_s3_task_role${local.resource_suffix}"
   metaflow_batch_image_name = "${local.resource_prefix}batch${local.resource_suffix}"
   metadata_service_container_image = (
@@ -21,4 +24,5 @@ locals {
     module.metaflow-common.default_ui_static_container_image :
     var.ui_static_container_image
   )
+  lb_access_logs_bucket_name = "${local.resource_prefix}elb-access-logs-${local.aws_account_id}-${local.aws_region_short}"
 }

--- a/main.tf
+++ b/main.tf
@@ -84,6 +84,7 @@ module "metaflow-ui" {
   ui_static_container_image       = local.ui_static_container_image
   alb_internal                    = var.ui_alb_internal
   ui_allow_list                   = var.ui_allow_list
+  lb_access_log_bucket            = var.enable_lb_access_logging ? aws_s3_bucket.elb_access_logs_bucket[0].id : null
 
   cognito_user_pool_arn       = var.ui_cognito_user_pool_arn
   cognito_user_pool_client_id = var.ui_cognito_user_pool_client_id

--- a/modules/ui/README.md
+++ b/modules/ui/README.md
@@ -71,6 +71,7 @@ The services are deployed behind an AWS ALB, and the module will output the ALB 
 | <a name="input_fargate_execution_role_arn"></a> [fargate\_execution\_role\_arn](#input\_fargate\_execution\_role\_arn) | This role allows Fargate to pull container images and logs. We'll use it as execution\_role for our Fargate task | `string` | n/a | yes |
 | <a name="input_iam_partition"></a> [iam\_partition](#input\_iam\_partition) | IAM Partition (Select aws-us-gov for AWS GovCloud, otherwise leave as is) | `string` | `"aws"` | no |
 | <a name="input_is_gov"></a> [is\_gov](#input\_is\_gov) | Set to true if IAM partition is 'aws-us-gov' | `bool` | `false` | no |
+| <a name="input_lb_access_log_bucket"></a> [lb\_access\_log\_bucket](#input\_lb\_access\_log\_bucket) | The bucket to store load balancer access logs | `string` | `null` | no |
 | <a name="input_load_balancer_name_prefix"></a> [load\_balancer\_name\_prefix](#input\_load\_balancer\_name\_prefix) | Prefix for all load balancer names | `string` | `""` | no |
 | <a name="input_metadata_service_security_group_id"></a> [metadata\_service\_security\_group\_id](#input\_metadata\_service\_security\_group\_id) | The security group ID used by the MetaData service. This security group should allow connections to the RDS instance. | `string` | n/a | yes |
 | <a name="input_metaflow_vpc_id"></a> [metaflow\_vpc\_id](#input\_metaflow\_vpc\_id) | VPC to deploy services into | `string` | n/a | yes |

--- a/modules/ui/ec2.tf
+++ b/modules/ui/ec2.tf
@@ -82,6 +82,15 @@ resource "aws_lb" "this" {
     aws_security_group.ui_lb_security_group.id
   ]
 
+  dynamic "access_logs" {
+    for_each = var.lb_access_log_bucket != null ? [1] : []
+    content {
+      bucket  = var.lb_access_log_bucket
+      enabled = true
+      prefix  = ""
+    }
+  }
+
   tags = var.standard_tags
 }
 

--- a/modules/ui/variables.tf
+++ b/modules/ui/variables.tf
@@ -154,3 +154,9 @@ variable "ecs_cluster_settings" {
   description = "Settings for the ECS cluster"
   default     = {}
 }
+
+variable "lb_access_log_bucket" {
+  type        = string
+  description = "The bucket to store load balancer access logs"
+  default     = null
+}

--- a/s3.tf
+++ b/s3.tf
@@ -1,0 +1,147 @@
+resource "aws_s3_bucket" "elb_access_logs_bucket" {
+  count = var.enable_lb_access_logging ? 1 : 0
+
+  bucket        = local.lb_access_logs_bucket_name
+  force_destroy = false
+  tags          = var.tags
+}
+
+resource "aws_s3_bucket_policy" "elb_access_logs_bucket" {
+  count = var.enable_lb_access_logging ? 1 : 0
+
+  bucket = local.lb_access_logs_bucket_name
+  policy = data.aws_iam_policy_document.elb_access_logs_bucket[0].json
+}
+
+resource "aws_s3_bucket_ownership_controls" "elb_access_logs_bucket" {
+  count = var.enable_lb_access_logging ? 1 : 0
+
+  bucket = local.lb_access_logs_bucket_name
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+
+  depends_on = [time_sleep.wait_for_aws_s3_bucket_settings]
+}
+
+resource "aws_s3_bucket_public_access_block" "elb_access_logs_bucket" {
+  count = var.enable_lb_access_logging ? 1 : 0
+
+  bucket                  = local.lb_access_logs_bucket_name
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "elb_access_logs_bucket" {
+  count = var.enable_lb_access_logging ? 1 : 0
+
+  bucket = local.lb_access_logs_bucket_name
+  rule {
+    bucket_key_enabled = false
+
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_versioning" "elb_access_logs_bucket" {
+  count  = var.enable_lb_access_logging ? 1 : 0
+  bucket = local.lb_access_logs_bucket_name
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "time_sleep" "wait_for_aws_s3_bucket_settings" {
+  count = var.enable_lb_access_logging ? 1 : 0
+
+  depends_on       = [aws_s3_bucket_public_access_block.elb_access_logs_bucket, aws_s3_bucket_policy.elb_access_logs_bucket]
+  create_duration  = "60s"
+  destroy_duration = "60s"
+}
+
+# https://docs.aws.amazon.com/elasticloadbalancing/latest/application/enable-access-logging.html
+data "aws_iam_policy_document" "elb_access_logs_bucket" {
+  count = var.enable_lb_access_logging ? 1 : 0
+
+  statement {
+    sid = "ForceSSLOnlyAccess"
+    actions = [
+      "s3:*",
+    ]
+    effect = "Deny"
+    resources = [
+      "arn:aws:s3:::${local.lb_access_logs_bucket_name}",
+      "arn:aws:s3:::${local.lb_access_logs_bucket_name}/*",
+    ]
+
+    condition {
+      test = "Bool"
+      values = [
+        "false",
+      ]
+      variable = "aws:SecureTransport"
+    }
+
+    principals {
+      identifiers = [
+        "*",
+      ]
+      type = "*"
+    }
+  }
+
+  statement {
+    sid       = "Allow the AWS Elastic Load Balancing to put access logs"
+    effect    = "Allow"
+    actions   = ["s3:PutObject"]
+    resources = ["arn:aws:s3:::${local.lb_access_logs_bucket_name}/AWSLogs/${data.aws_caller_identity.current.id}/*"]
+
+    principals {
+      type = var.region_available_before_2022 ? "AWS" : "Service"
+      # https://docs.aws.amazon.com/elasticloadbalancing/latest/application/enable-access-logging.html#attach-bucket-policy
+      identifiers = var.region_available_before_2022 ? [data.aws_elb_service_account.current.arn] : ["logdelivery.elasticloadbalancing.amazonaws.com"]
+    }
+  }
+
+  statement {
+    sid       = "Restrict to AWS Elastic Load Balancing"
+    effect    = "Deny"
+    actions   = ["s3:PutObject"]
+    resources = ["arn:aws:s3:::${local.lb_access_logs_bucket_name}/*"]
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+
+    condition {
+      test     = "ForAllValues:StringNotEquals"
+      variable = "aws:PrincipalServiceNamesList"
+      values   = ["logdelivery.elasticloadbalancing.amazonaws.com"]
+    }
+  }
+
+  statement {
+    sid    = "Deny any modification or removal of ELB access logs"
+    effect = "Deny"
+    actions = [
+      "s3:DeleteObject",
+      "s3:DeleteObjectVersion",
+      "s3:PutLifecycleConfiguration"
+    ]
+    resources = [
+      "arn:aws:s3:::${local.lb_access_logs_bucket_name}",
+      "arn:aws:s3:::${local.lb_access_logs_bucket_name}/*"
+    ]
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -311,3 +311,15 @@ variable "ecs_cluster_settings" {
   description = "Settings for the ECS cluster"
   default     = {}
 }
+
+variable "enable_lb_access_logging" {
+  type        = bool
+  description = "Enable access logging for all load balancers"
+  default     = false
+}
+
+variable "region_available_before_2022" {
+  type        = bool
+  default     = true
+  description = "Set to false if the region is not available before 2022. This is used for the ELB access logging bucket policy, as older regions have different bucket policy principle statements, see: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/enable-access-logging.html#attach-bucket-policy"
+}


### PR DESCRIPTION
Considerations:

- Tested initially using the [terraform-aws-s3-bucket](https://github.com/cloudposse/terraform-aws-s3-bucket) module. However had repeatable timing issues between applying the custom policy to allow the ELB service writing to the bucket, and enabling access logging on the ALB. [This wait](https://github.com/cloudposse/terraform-aws-s3-bucket/blob/main/main.tf#L576-L582) in the module is intended to resolve such issues, however it was not long enough hence why we are waiting longer (60s) and describing the resources ourselves. Probably better to do this anyway in terms of making further changes.
- The bucket policy to allow the ELB service to write objects needs to be different depending on the region as described [here](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/enable-access-logging.html#attach-bucket-policy). Hence the reason for the `region_available_before_2022` variable to add support for all regions
- Decided not to implement NLB access logging at this time, for a couple of reasons
  - NLB access logging will only log for TLS connections as explained [here](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/enable-access-logs.html#access-logging-bucket-requirements). Currently the module only creates TCP listeners
  - Also explained there, for NLB access logging, the S3 bucket does not support SSE-S3 as with the ELB bucket, it needs to be SSE-KMS. Therefore we can't utilise the same bucket, so bucket pattern here can be re-used when that support becomes available (if ever)
- The S3 bucket name contains the prefix, which ensures it will be unique per metaflow deployment