### PR TITLE
IN-134: Always configure the ALB access_logs attribute

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -84,7 +84,7 @@ module "metaflow-ui" {
   ui_static_container_image       = local.ui_static_container_image
   alb_internal                    = var.ui_alb_internal
   ui_allow_list                   = var.ui_allow_list
-  elb_access_logging_bucket       = var.elb_access_logging_enabled ? aws_s3_bucket.elb_access_logs_bucket[0].id : null
+  elb_access_logging_bucket       = var.elb_access_logging_enabled ? aws_s3_bucket.elb_access_logs_bucket[0].id : ""
 
   cognito_user_pool_arn       = var.ui_cognito_user_pool_arn
   cognito_user_pool_client_id = var.ui_cognito_user_pool_client_id

--- a/modules/ui/README.md
+++ b/modules/ui/README.md
@@ -66,7 +66,7 @@ The services are deployed behind an AWS ALB, and the module will output the ALB 
 | <a name="input_database_username"></a> [database\_username](#input\_database\_username) | The database username | `string` | n/a | yes |
 | <a name="input_datastore_s3_bucket_kms_key_arn"></a> [datastore\_s3\_bucket\_kms\_key\_arn](#input\_datastore\_s3\_bucket\_kms\_key\_arn) | The ARN of the KMS key used to encrypt the Metaflow datastore S3 bucket | `string` | n/a | yes |
 | <a name="input_ecs_cluster_settings"></a> [ecs\_cluster\_settings](#input\_ecs\_cluster\_settings) | Settings for the ECS cluster | `map(string)` | `{}` | no |
-| <a name="input_elb_access_logging_bucket"></a> [elb\_access\_logging\_bucket](#input\_elb\_access\_logging\_bucket) | The bucket to store ELB access logs | `string` | `null` | no |
+| <a name="input_elb_access_logging_bucket"></a> [elb\_access\_logging\_bucket](#input\_elb\_access\_logging\_bucket) | The bucket to store ELB access logs | `string` | `""` | no |
 | <a name="input_extra_ui_backend_env_vars"></a> [extra\_ui\_backend\_env\_vars](#input\_extra\_ui\_backend\_env\_vars) | Additional environment variables for UI backend container | `map(string)` | `{}` | no |
 | <a name="input_extra_ui_static_env_vars"></a> [extra\_ui\_static\_env\_vars](#input\_extra\_ui\_static\_env\_vars) | Additional environment variables for UI static app | `map(string)` | `{}` | no |
 | <a name="input_fargate_execution_role_arn"></a> [fargate\_execution\_role\_arn](#input\_fargate\_execution\_role\_arn) | This role allows Fargate to pull container images and logs. We'll use it as execution\_role for our Fargate task | `string` | n/a | yes |

--- a/modules/ui/ec2.tf
+++ b/modules/ui/ec2.tf
@@ -82,13 +82,10 @@ resource "aws_lb" "this" {
     aws_security_group.ui_lb_security_group.id
   ]
 
-  dynamic "access_logs" {
-    for_each = var.elb_access_logging_bucket != null ? [1] : []
-    content {
-      bucket  = var.elb_access_logging_bucket
-      enabled = true
-      prefix  = ""
-    }
+  access_logs {
+    bucket  = var.elb_access_logging_bucket != "" ? var.elb_access_logging_bucket : null
+    enabled = var.elb_access_logging_bucket != "" ? true : false
+    prefix  = var.elb_access_logging_bucket != "" ? "" : null
   }
 
   tags = var.standard_tags

--- a/modules/ui/variables.tf
+++ b/modules/ui/variables.tf
@@ -158,5 +158,5 @@ variable "ecs_cluster_settings" {
 variable "elb_access_logging_bucket" {
   type        = string
   description = "The bucket to store ELB access logs"
-  default     = null
+  default     = ""
 }


### PR DESCRIPTION
IN-134: As the access_logs argument is always configured but defaulted to 'false', there is no need to have it dynamic. Instead we configure it as enabled depending on if the bucket name is configured. This will provide clearer terraform plan output as we are seeing odd behaviour with the 'null' alternative, plan's wanting to delete the access_logs attribute but not change it.
```
-       access_logs {
-           enabled = false -> null
        }
```