### PR TITLE
IN-348: Support db_snapshot_identifier for the datastore RDS

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ You can find a more complete example that uses this module but also includes set
 | <a name="input_database_ssl_mode"></a> [database\_ssl\_mode](#input\_database\_ssl\_mode) | The database SSL mode | `string` | `"disable"` | no |
 | <a name="input_database_ssl_root_cert"></a> [database\_ssl\_root\_cert](#input\_database\_ssl\_root\_cert) | The database SSL root certificate | `string` | `""` | no |
 | <a name="input_db_allow_major_version_upgrade"></a> [db\_allow\_major\_version\_upgrade](#input\_db\_allow\_major\_version\_upgrade) | Allow major version upgrades for the RDS instance | `bool` | `false` | no |
-| <a name="input_db_auto_minor_version_upgrade"></a> [db\_auto\_minor\_version\_upgrade](#input\_db\_auto\_minor\_version\_upgrade) | Enable auto minor version upgrade for the RDS instance | `bool` | `false` | no |
+| <a name="input_db_auto_minor_version_upgrade"></a> [db\_auto\_minor\_version\_upgrade](#input\_db\_auto\_minor\_version\_upgrade) | Enable auto minor version upgrade for the RDS instance | `bool` | `true` | no |
 | <a name="input_db_engine_version"></a> [db\_engine\_version](#input\_db\_engine\_version) | n/a | `string` | `"11"` | no |
 | <a name="input_db_identifier_prefix"></a> [db\_identifier\_prefix](#input\_db\_identifier\_prefix) | Identifier prefix for the RDS instance | `string` | `""` | no |
 | <a name="input_db_instance_tags"></a> [db\_instance\_tags](#input\_db\_instance\_tags) | A map of additional tags for the DB instance | `map(string)` | `{}` | no |
@@ -121,6 +121,7 @@ You can find a more complete example that uses this module but also includes set
 | <a name="input_db_migrate_lambda_zip_file"></a> [db\_migrate\_lambda\_zip\_file](#input\_db\_migrate\_lambda\_zip\_file) | Output path for the zip file containing the DB migrate lambda | `string` | `null` | no |
 | <a name="input_db_multi_az"></a> [db\_multi\_az](#input\_db\_multi\_az) | Enable Multi-AZ for the RDS instance | `bool` | `true` | no |
 | <a name="input_db_parameters"></a> [db\_parameters](#input\_db\_parameters) | A map of parameters to apply to the DB instance | `map(string)` | `{}` | no |
+| <a name="input_db_snapshot_identifier"></a> [db\_snapshot\_identifier](#input\_db\_snapshot\_identifier) | The snapshot identifier to restore the RDS instance from, or leave blank to create a new instance | `string` | `null` | no |
 | <a name="input_ecs_cluster_settings"></a> [ecs\_cluster\_settings](#input\_ecs\_cluster\_settings) | Settings for the ECS cluster | `map(string)` | `{}` | no |
 | <a name="input_elb_access_logging_bucket_prefix"></a> [elb\_access\_logging\_bucket\_prefix](#input\_elb\_access\_logging\_bucket\_prefix) | Optional Prefix for the ELB access logging bucket | `string` | `""` | no |
 | <a name="input_elb_access_logging_enabled"></a> [elb\_access\_logging\_enabled](#input\_elb\_access\_logging\_enabled) | Enable access logging for all Elastic Load Balancers | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -8,6 +8,7 @@ module "metaflow-datastore" {
   metaflow_vpc_id                    = var.vpc_id
   subnet1_id                         = var.subnet1_id
   subnet2_id                         = var.subnet2_id
+  db_snapshot_identifier             = var.db_snapshot_identifier
   db_identifier_prefix               = var.db_identifier_prefix
   db_instance_type                   = var.db_instance_type
   db_engine_version                  = var.db_engine_version

--- a/modules/datastore/README.md
+++ b/modules/datastore/README.md
@@ -58,7 +58,7 @@ No modules.
 | <a name="input_bucket_key_enabled"></a> [bucket\_key\_enabled](#input\_bucket\_key\_enabled) | Whether or not to use Amazon S3 Bucket Keys for SSE-KMS | `bool` | `false` | no |
 | <a name="input_ca_cert_identifier"></a> [ca\_cert\_identifier](#input\_ca\_cert\_identifier) | RDS CA cert identifier for the DB Instances, or leave blank for RDS default | `string` | `""` | no |
 | <a name="input_db_allow_major_version_upgrade"></a> [db\_allow\_major\_version\_upgrade](#input\_db\_allow\_major\_version\_upgrade) | Allow major version upgrades for the RDS instance | `bool` | `false` | no |
-| <a name="input_db_auto_minor_version_upgrade"></a> [db\_auto\_minor\_version\_upgrade](#input\_db\_auto\_minor\_version\_upgrade) | Enable auto minor version upgrade for the RDS instance | `bool` | `false` | no |
+| <a name="input_db_auto_minor_version_upgrade"></a> [db\_auto\_minor\_version\_upgrade](#input\_db\_auto\_minor\_version\_upgrade) | Enable auto minor version upgrade for the RDS instance | `bool` | `true` | no |
 | <a name="input_db_engine"></a> [db\_engine](#input\_db\_engine) | n/a | `string` | `"postgres"` | no |
 | <a name="input_db_engine_version"></a> [db\_engine\_version](#input\_db\_engine\_version) | n/a | `string` | `"11"` | no |
 | <a name="input_db_identifier_prefix"></a> [db\_identifier\_prefix](#input\_db\_identifier\_prefix) | Identifier prefix for the RDS instance | `string` | `""` | no |
@@ -67,6 +67,7 @@ No modules.
 | <a name="input_db_multi_az"></a> [db\_multi\_az](#input\_db\_multi\_az) | Enable Multi-AZ for the RDS instance | `bool` | `true` | no |
 | <a name="input_db_name"></a> [db\_name](#input\_db\_name) | Name of PostgresQL database for Metaflow service. | `string` | `"metaflow"` | no |
 | <a name="input_db_parameters"></a> [db\_parameters](#input\_db\_parameters) | A map of parameters to apply to the DB instance | `map(string)` | `{}` | no |
+| <a name="input_db_snapshot_identifier"></a> [db\_snapshot\_identifier](#input\_db\_snapshot\_identifier) | The snapshot identifier to restore the RDS instance from, or leave blank to create a new instance | `string` | `null` | no |
 | <a name="input_db_username"></a> [db\_username](#input\_db\_username) | PostgresQL username; defaults to 'metaflow' | `string` | `"metaflow"` | no |
 | <a name="input_force_destroy_s3_bucket"></a> [force\_destroy\_s3\_bucket](#input\_force\_destroy\_s3\_bucket) | Empty S3 bucket before destroying via terraform destroy | `bool` | `false` | no |
 | <a name="input_maintenance_window"></a> [maintenance\_window](#input\_maintenance\_window) | Maintenance Window in format "ddd:hh24:mi-ddd:hh24:mi" eg. "Mon:00:00-Mon:03:00", or leave blank to randomise | `string` | `""` | no |

--- a/modules/datastore/rds.tf
+++ b/modules/datastore/rds.tf
@@ -116,6 +116,7 @@ resource "aws_db_instance" "this" {
   instance_class            = var.db_instance_type    # Hardware configuration
   identifier                = local.rds_db_identifier # used for dns hostname needs to be customer unique in region
   db_name                   = var.db_name             # unique id for CLI commands (name of DB table which is why we're not adding the prefix as no conflicts will occur and the API expects this table name)
+  snapshot_identifier       = var.db_snapshot_identifier
   username                  = var.db_username
   password                  = random_password.this.result
   db_subnet_group_name      = aws_db_subnet_group.this.id

--- a/modules/datastore/variables.tf
+++ b/modules/datastore/variables.tf
@@ -1,3 +1,9 @@
+variable "db_snapshot_identifier" {
+  type        = string
+  description = "The snapshot identifier to restore the RDS instance from, or leave blank to create a new instance"
+  default     = null
+}
+
 variable "db_instance_type" {
   type        = string
   description = "RDS instance type to launch for PostgresQL database."

--- a/variables.tf
+++ b/variables.tf
@@ -22,6 +22,12 @@ variable "batch_type" {
   default     = "ec2"
 }
 
+variable "db_snapshot_identifier" {
+  type        = string
+  description = "The snapshot identifier to restore the RDS instance from, or leave blank to create a new instance"
+  default     = null
+}
+
 variable "db_identifier_prefix" {
   type        = string
   description = "Identifier prefix for the RDS instance"


### PR DESCRIPTION
IN-348: Support db_snapshot_identifier for the datastore RDS, so that 
if we are bringing back and RDS instance we have the option to use a backup from a snapshot.